### PR TITLE
Remove debugging statements in master

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -42,5 +42,3 @@ module.exports =
       @manager.on 'selector:show', =>
         view = new VirtualenvListView(@manager)
         view.attach()
-
-      console.log("virtualenv activated")

--- a/lib/virtualenv-manager.coffee
+++ b/lib/virtualenv-manager.coffee
@@ -82,7 +82,6 @@ module.exports =
           @emit('options', @options)
         if @options.length == 1 and not @wrapper
           @change(@options[0])
-        console.log(@options)
 
     ignore: (path) ->
       if @wrapper


### PR DESCRIPTION
Hey I'm working on a plugin and these statements are cluttering up my console. I'm suggesting removing them to keep things clean in prod code. Other than that your plugin is quite helpful

Thanks
Nick Shobe
