### PR TITLE
Correct use of now deprecated '.workspace' to 'atom-workspace' selectors

### DIFF
--- a/keymaps/virtualenv.cson
+++ b/keymaps/virtualenv.cson
@@ -7,7 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-v': 'virtualenv:select'
   'ctrl-alt-cmd-v': 'virtualenv:make'
   'ctrl-alt-shift-v': 'virtualenv:deactivate'


### PR DESCRIPTION
This should also close:
#20 #19 #23 #17 #18 
