### PR TITLE
update engine to support post-1.0 atom versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jhutchins/virtualenv",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
     "status-bar": ">=0.41.0"


### PR DESCRIPTION
This commit updates the package.json to indicate compatibility with versions of atom between 1.0 and 2.0.

See the comment package for [a fix to a similar issue](https://github.com/javaguirre/comment/pull/24/commits/390e8bec6a1b2176badfa124f27e5ff78603d8fd)

To install run:

```
$ apm install bengt/virtualenv
```

This should fix the issues #37 and #38.
